### PR TITLE
Adds Purge and None verbs to EntityEvents

### DIFF
--- a/src/libraries/EntityEvents.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/libraries/EntityEvents.Abstractions/PublicAPI.Unshipped.txt
@@ -9,5 +9,7 @@ Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<T>.Verb.get -> Innago.Pl
 Innago.Platform.Messaging.EntityEvents.Verb
 Innago.Platform.Messaging.EntityEvents.Verb.Create = 0 -> Innago.Platform.Messaging.EntityEvents.Verb
 Innago.Platform.Messaging.EntityEvents.Verb.Delete = 2 -> Innago.Platform.Messaging.EntityEvents.Verb
+Innago.Platform.Messaging.EntityEvents.Verb.None = -1 -> Innago.Platform.Messaging.EntityEvents.Verb
+Innago.Platform.Messaging.EntityEvents.Verb.Purge = 3 -> Innago.Platform.Messaging.EntityEvents.Verb
 Innago.Platform.Messaging.EntityEvents.Verb.Update = 1 -> Innago.Platform.Messaging.EntityEvents.Verb
 static Innago.Platform.Messaging.EntityEvents.EntityEventInfoExtensions.ToCloudEvent<T>(this Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<T>! entityEventInfo) -> CloudNative.CloudEvents.CloudEvent!

--- a/src/libraries/EntityEvents.Abstractions/Verb.cs
+++ b/src/libraries/EntityEvents.Abstractions/Verb.cs
@@ -6,6 +6,12 @@ namespace Innago.Platform.Messaging.EntityEvents;
 public enum Verb
 {
     /// <summary>
+    /// Represents the absence of a specific action or operation on an entity.
+    /// This verb is used when no particular operation has been performed or when the action is undefined.
+    /// </summary>
+    None = -1,
+
+    /// <summary>
     /// Represents the action of creating a new entity.
     /// This verb is used to indicate that a new entity has been added to the system,
     /// and an associated event has occurred to reflect this operation.
@@ -25,4 +31,10 @@ public enum Verb
     /// from the system, and an associated event reflects the removal operation.
     /// </summary>
     Delete,
+
+    /// <summary>
+    /// Represents a verb indicating the complete removal of an entity and its associated data from the system.
+    /// This action is irreversible and denotes permanent deletion beyond basic deletion operations.
+    /// </summary>
+    Purge
 }

--- a/tests/ApprovalTests/ApprovalTests.csproj
+++ b/tests/ApprovalTests/ApprovalTests.csproj
@@ -35,7 +35,7 @@
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
-        <PackageReference Include="Verify.Xunit" Version="29.3.1" />
+        <PackageReference Include="Verify.Xunit" Version="29.4.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.OpenCategories" Version="2.1.1.9" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">

--- a/tests/ApprovalTests/EntityEvents.Abstractions/ApprovedApi/netstandard2.0.verified.txt
+++ b/tests/ApprovalTests/EntityEvents.Abstractions/ApprovedApi/netstandard2.0.verified.txt
@@ -15,8 +15,10 @@
     }
     public enum Verb
     {
+        None = -1,
         Create = 0,
         Update = 1,
         Delete = 2,
+        Purge = 3,
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add `None` and `Purge` verbs to the `Verb` enum.

Enhancements:
- Introduce `None` to represent the absence of an action.
- Introduce `Purge` to represent the complete removal of an entity and its data.