### PR TITLE
Adds IEntityEventInfo overload to IPublisher.PublishAsync.

### DIFF
--- a/examples/RabbitPoc/MyHostedService.cs
+++ b/examples/RabbitPoc/MyHostedService.cs
@@ -19,7 +19,7 @@ internal class MyHostedService(IPublisher publisher) : IHostedService
 
             await publisher.PublishAsync(entityEvent);
 
-            Thread.Sleep(1_000);
+            await Task.Delay(1_000, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/examples/RabbitPoc/MyHostedService.cs
+++ b/examples/RabbitPoc/MyHostedService.cs
@@ -2,8 +2,6 @@ namespace RabbitPoc;
 
 using Bogus;
 
-using CloudNative.CloudEvents;
-
 using Innago.Platform.Messaging.EntityEvents;
 using Innago.Platform.Messaging.Publisher;
 
@@ -17,9 +15,9 @@ internal class MyHostedService(IPublisher publisher) : IHostedService
     {
         while (!cancellationToken.IsCancellationRequested)
         {
-            CloudEvent cloudEvent = MakeCloudEvent();
+            IEntityEventInfo<SomeEntity> entityEvent = MakeEntityEvent();
 
-            await publisher.PublishAsync<SomeEntity>(cloudEvent);
+            await publisher.PublishAsync(entityEvent);
 
             Thread.Sleep(1_000);
         }
@@ -30,7 +28,7 @@ internal class MyHostedService(IPublisher publisher) : IHostedService
         return publisher.DisposeAsync().AsTask();
     }
 
-    private static CloudEvent MakeCloudEvent()
+    private static IEntityEventInfo<SomeEntity> MakeEntityEvent()
     {
         var verb = MyHostedService.Faker.PickRandom<Verb>();
         string entityId = MyHostedService.Faker.Random.AlphaNumeric(8);
@@ -39,11 +37,10 @@ internal class MyHostedService(IPublisher publisher) : IHostedService
         var data = new SomeEntity(MyHostedService.Faker.Commerce.Color());
 
         var info = new EntityEventInfo<SomeEntity>(entityId, verb, tenantId, Data: data);
-
-        var cloudEvent = info.ToCloudEvent();
-
-        return cloudEvent;
+        
+        return info;
     }
 
+    // ReSharper disable once NotAccessedPositionalProperty.Local
     private record SomeEntity(string Value);
 }

--- a/src/libraries/Publisher.Abstractions/IPublisher.cs
+++ b/src/libraries/Publisher.Abstractions/IPublisher.cs
@@ -2,6 +2,8 @@ namespace Innago.Platform.Messaging.Publisher;
 
 using CloudNative.CloudEvents;
 
+using EntityEvents;
+
 /// <summary>
 /// Defines a contract for publishing CloudEvent messages.
 /// Implementations of this interface are responsible for sending event data
@@ -16,4 +18,12 @@ public interface IPublisher : IAsyncDisposable
     /// <typeparam name="T">The type of the payload contained in the CloudEvent.</typeparam>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public Task PublishAsync<T>(CloudEvent cloudEvent);
+
+    /// <summary>
+    /// Publishes an entity event asynchronously.
+    /// </summary>
+    /// <param name="entityEventInfo">The event information containing details about the entity event.</param>
+    /// <typeparam name="T">The type of the data associated with the entity event.</typeparam>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public Task PublishAsync<T>(IEntityEventInfo<T> entityEventInfo);
 }

--- a/src/libraries/Publisher.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/libraries/Publisher.Abstractions/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 Innago.Platform.Messaging.Publisher.IPublisher
 Innago.Platform.Messaging.Publisher.IPublisher.PublishAsync<T>(CloudNative.CloudEvents.CloudEvent! cloudEvent) -> System.Threading.Tasks.Task!
+Innago.Platform.Messaging.Publisher.IPublisher.PublishAsync<T>(Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<T>! entityEventInfo) -> System.Threading.Tasks.Task!

--- a/src/libraries/Publisher.Abstractions/Publisher.Abstractions.csproj
+++ b/src/libraries/Publisher.Abstractions/Publisher.Abstractions.csproj
@@ -54,4 +54,8 @@
         <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\EntityEvents.Abstractions\EntityEvents.Abstractions.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/libraries/Publisher.Amqp/PublicAPI.Unshipped.txt
+++ b/src/libraries/Publisher.Amqp/PublicAPI.Unshipped.txt
@@ -2,5 +2,6 @@ Innago.Platform.Messaging.Publisher.Amqp.DependencyInjection
 Innago.Platform.Messaging.Publisher.Amqp.Publisher
 Innago.Platform.Messaging.Publisher.Amqp.Publisher.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Innago.Platform.Messaging.Publisher.Amqp.Publisher.PublishAsync<T>(CloudNative.CloudEvents.CloudEvent! cloudEvent) -> System.Threading.Tasks.Task!
+Innago.Platform.Messaging.Publisher.Amqp.Publisher.PublishAsync<T>(Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<T>! entityEventInfo) -> System.Threading.Tasks.Task!
 Innago.Platform.Messaging.Publisher.Amqp.Publisher.Publisher(Amqp.IConnection! connection, Microsoft.Extensions.Logging.ILogger<Innago.Platform.Messaging.Publisher.Amqp.Publisher!>! logger, string! addressPrefix, string! senderName) -> void
 static Innago.Platform.Messaging.Publisher.Amqp.DependencyInjection.AddAmqpCloudEventsPublisher(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfiguration! configuration, string? sectionName = "publisherAmqp") -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/libraries/Publisher.Amqp/Publisher.cs
+++ b/src/libraries/Publisher.Amqp/Publisher.cs
@@ -6,6 +6,8 @@ using CloudNative.CloudEvents;
 using CloudNative.CloudEvents.Amqp;
 using CloudNative.CloudEvents.SystemTextJson;
 
+using EntityEvents;
+
 using global::Amqp;
 using global::Amqp.Framing;
 
@@ -60,5 +62,11 @@ public sealed class Publisher(
         {
             await link.CloseAsync().ConfigureAwait(false);
         }
+    }
+
+    /// <inheritdoc />
+    public Task PublishAsync<T>(IEntityEventInfo<T> entityEventInfo)
+    {
+        return this.PublishAsync<T>(entityEventInfo.ToCloudEvent());
     }
 }

--- a/tests/ApprovalTests/Publisher.Abstractions/ApprovedApi/net9.0.verified.txt
+++ b/tests/ApprovalTests/Publisher.Abstractions/ApprovedApi/net9.0.verified.txt
@@ -4,5 +4,6 @@ namespace Innago.Platform.Messaging.Publisher
     public interface IPublisher : System.IAsyncDisposable
     {
         System.Threading.Tasks.Task PublishAsync<T>(CloudNative.CloudEvents.CloudEvent cloudEvent);
+        System.Threading.Tasks.Task PublishAsync<T>(Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<T> entityEventInfo);
     }
 }

--- a/tests/ApprovalTests/Publisher.Abstractions/ApprovedApi/netstandard2.0.verified.txt
+++ b/tests/ApprovalTests/Publisher.Abstractions/ApprovedApi/netstandard2.0.verified.txt
@@ -3,5 +3,6 @@
     public interface IPublisher : System.IAsyncDisposable
     {
         System.Threading.Tasks.Task PublishAsync<T>(CloudNative.CloudEvents.CloudEvent cloudEvent);
+        System.Threading.Tasks.Task PublishAsync<T>(Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<T> entityEventInfo);
     }
 }

--- a/tests/ApprovalTests/Publisher.Amqp/ApprovedApi/net9.0.verified.txt
+++ b/tests/ApprovalTests/Publisher.Amqp/ApprovedApi/net9.0.verified.txt
@@ -10,5 +10,6 @@ namespace Innago.Platform.Messaging.Publisher.Amqp
         public Publisher(Amqp.IConnection connection, Microsoft.Extensions.Logging.ILogger<Innago.Platform.Messaging.Publisher.Amqp.Publisher> logger, string addressPrefix, string senderName) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.Task PublishAsync<T>(CloudNative.CloudEvents.CloudEvent cloudEvent) { }
+        public System.Threading.Tasks.Task PublishAsync<T>(Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<T> entityEventInfo) { }
     }
 }

--- a/tests/ApprovalTests/Publisher.Amqp/ApprovedApi/netstandard2.0.verified.txt
+++ b/tests/ApprovalTests/Publisher.Amqp/ApprovedApi/netstandard2.0.verified.txt
@@ -9,5 +9,6 @@
         public Publisher(Amqp.IConnection connection, Microsoft.Extensions.Logging.ILogger<Innago.Platform.Messaging.Publisher.Amqp.Publisher> logger, string addressPrefix, string senderName) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.Task PublishAsync<T>(CloudNative.CloudEvents.CloudEvent cloudEvent) { }
+        public System.Threading.Tasks.Task PublishAsync<T>(Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<T> entityEventInfo) { }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add an overload to `IPublisher` for publishing `IEntityEventInfo` directly.

New Features:
- Add `PublishAsync<T>(IEntityEventInfo<T> entityEventInfo)` method to the `IPublisher` interface to simplify publishing entity events.
- Implement the new `PublishAsync` overload in the AMQP publisher implementation by converting the event info to a CloudEvent first.
- Update the example service to use the new `PublishAsync` overload, removing the manual CloudEvent conversion step.
- Update public API tracking files and approval tests to reflect the new interface method.