### PR TITLE
feat(rabbitpoc): add health checks and OpenTelemetry support

### DIFF
--- a/.github/actions/check-licenses-action/ignored-packages.json
+++ b/.github/actions/check-licenses-action/ignored-packages.json
@@ -8,5 +8,6 @@
   "NETStandard.Library",
   "FluentAssertions",
   "Bogus",
-  "Innago.Shared.TryHelpers"
+  "Innago.Shared.TryHelpers",
+  "Innago.Shared.HealthChecks.TcpHealthProbe"
 ]

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -20,4 +20,7 @@ jobs:
       pull-requests: write
       id-token: write
       contents: read
+    with: 
+      argoCdRepoName: "${{ github.repository_owner }}/argocd-shared"
+      imageName: 'innago.platform.messaging.cloudevents.console-example'
     

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
+nuget_password.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+ARG TARGETARCH
+WORKDIR /work
+
+ARG NUGET_SOURCE_NAME
+ARG NUGET_SOURCE_URL
+ARG NUGET_USERNAME
+
+RUN --mount=type=secret,id=nuget_password,target=/run/secrets/nuget_password \
+    if [ -n "$NUGET_SOURCE_URL" ] && [ -n "$NUGET_USERNAME" ]; then \
+        NUGET_PASSWORD_FROM_SECRET=$(cat /run/secrets/nuget_password); \
+        dotnet nuget add source \
+            --name "$NUGET_SOURCE_NAME" \
+            --username "$NUGET_USERNAME" \
+            --password "$NUGET_PASSWORD_FROM_SECRET" \
+            --store-password-in-clear-text \
+            "$NUGET_SOURCE_URL"; \
+    fi
+    
+#RUN apt-get update && apt install gcc --yes
+
+COPY . .
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+#RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM and $TARGETARCH" > /log
+
+RUN dotnet restore examples/RabbitPoc/RabbitPoc.csproj  --arch $TARGETARCH
+
+RUN dotnet publish examples/RabbitPoc/RabbitPoc.csproj  \
+    --no-restore \
+    --configuration Release \
+    --output /app \
+    --self-contained false \
+    /p:NoWarn=RS0041 \
+    --arch $TARGETARCH \
+    -p:SKIP_OPENAPI_GENERATION=true
+    
+
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:9.0-alpine AS app
+
+LABEL vendor="Innago"
+LABEL com.innago.image="Innago.CloudEventsExample"
+
+RUN apk update --no-cache && apk upgrade --no-cache && rm -rf /var/cache/apk/*
+
+RUN addgroup --gid 10001 notroot \
+    && adduser --uid 10001 --ingroup notroot notroot --disabled-password --no-create-home
+
+WORKDIR /app
+COPY --from=build /app .
+
+USER notroot:notroot
+ENV DOTNET_EnableDiagnostics=1
+ENV DOTNET_EnableDiagnostics_IPC=0
+ENV DOTNET_EnableDiagnostics_Debugger=0
+ENV DOTNET_EnableDiagnostics_Profiler=1
+ENV ASPNETCORE_HOSTBUILDER_RELOADCONFIGONCHANGE="false"
+
+ENTRYPOINT ["dotnet","Innago.Platform.Messaging.CloudEvents.ConsoleExample.dll"]

--- a/examples/RabbitPoc/MyHostedService.cs
+++ b/examples/RabbitPoc/MyHostedService.cs
@@ -20,7 +20,7 @@ internal class MyHostedService(IPublisher publisher) : IHostedService
 
             await TryHelpers.TryAsync(() => publisher.PublishAsync(entityEvent)).ConfigureAwait(false);
 
-            await Task.Delay(1_000, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(30_000, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/examples/RabbitPoc/Program.cs
+++ b/examples/RabbitPoc/Program.cs
@@ -28,14 +28,14 @@ builder.ConfigureServices((context, services) =>
     services.AddAmqpCloudEventsPublisher(context.Configuration);
     services.AddHostedService<MyHostedService>();
     services.AddHealthChecks().AddRabbitMQ();
-    
+
     string serviceName = context.Configuration["serviceName"] ?? "RabbitPoc";
     string serviceVersion = context.Configuration["serviceVersion"] ?? "0.0.1";
-    
+
     services.AddOpenTelemetry()
         .ConfigureResource(ConfigureResource(serviceName, serviceVersion))
         .WithTracing(ConfigureTracing(context.Configuration, serviceName))
-        .WithMetrics(ConfigureMetrics(serviceName));
+        .WithMetrics(ConfigureMetrics(context.Configuration, serviceName));
 });
 
 await builder.RunConsoleAsync();

--- a/examples/RabbitPoc/ProgramConfiguration.cs
+++ b/examples/RabbitPoc/ProgramConfiguration.cs
@@ -1,0 +1,54 @@
+namespace RabbitPoc;
+
+using Microsoft.Extensions.Configuration;
+
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+internal static class ProgramConfiguration
+{
+    internal static Action<MeterProviderBuilder> ConfigureMetrics(string serviceName)
+    {
+        return Configure;
+
+        void Configure(MeterProviderBuilder meterProviderBuilder)
+        {
+            meterProviderBuilder.AddMeter(serviceName);
+        }
+    }
+
+    internal static Action<ResourceBuilder> ConfigureResource(string serviceName, string serviceVersion)
+    {
+        return Configure;
+
+        void Configure(ResourceBuilder resourceBuilder)
+        {
+            resourceBuilder.AddService(serviceName, serviceVersion);
+        }
+    }
+
+    internal static Action<TracerProviderBuilder> ConfigureTracing(
+        IConfiguration configuration,
+        string serviceName)
+    {
+        return Configure;
+
+        void Configure(TracerProviderBuilder tracerProviderBuilder)
+        {
+            tracerProviderBuilder.AddSource(serviceName);
+
+            tracerProviderBuilder.AddOtlpExporter(options =>
+            {
+                options.Protocol = OtlpExportProtocol.HttpProtobuf;
+                options.Endpoint = new Uri(configuration["otlpEndpoint"] ?? throw new InvalidOperationException("missing otlp uri"));
+            });
+
+            if (configuration["ASPNETCORE_ENVIRONMENT"] == "Development")
+            {
+                tracerProviderBuilder.AddConsoleExporter();
+            }
+        }
+    }
+}

--- a/examples/RabbitPoc/ProgramConfiguration.cs
+++ b/examples/RabbitPoc/ProgramConfiguration.cs
@@ -9,13 +9,14 @@ using OpenTelemetry.Trace;
 
 internal static class ProgramConfiguration
 {
-    internal static Action<MeterProviderBuilder> ConfigureMetrics(string serviceName)
+    internal static Action<MeterProviderBuilder> ConfigureMetrics(IConfiguration configuration, string serviceName)
     {
         return Configure;
 
         void Configure(MeterProviderBuilder meterProviderBuilder)
         {
             meterProviderBuilder.AddMeter(serviceName);
+            meterProviderBuilder.AddOtlpExporter(ConfigureOtlpExporter(configuration));
         }
     }
 
@@ -39,16 +40,23 @@ internal static class ProgramConfiguration
         {
             tracerProviderBuilder.AddSource(serviceName);
 
-            tracerProviderBuilder.AddOtlpExporter(options =>
-            {
-                options.Protocol = OtlpExportProtocol.HttpProtobuf;
-                options.Endpoint = new Uri(configuration["otlpEndpoint"] ?? throw new InvalidOperationException("missing otlp uri"));
-            });
+            tracerProviderBuilder.AddOtlpExporter(ConfigureOtlpExporter(configuration));
 
             if (configuration["ASPNETCORE_ENVIRONMENT"] == "Development")
             {
                 tracerProviderBuilder.AddConsoleExporter();
             }
+        }
+    }
+
+    private static Action<OtlpExporterOptions> ConfigureOtlpExporter(IConfiguration configuration)
+    {
+        return Configure;
+
+        void Configure(OtlpExporterOptions options)
+        {
+            options.Protocol = OtlpExportProtocol.HttpProtobuf;
+            options.Endpoint = new Uri(configuration["otlpEndpoint"] ?? throw new InvalidOperationException("missing otlp uri"));
         }
     }
 }

--- a/examples/RabbitPoc/RabbitPoc.csproj
+++ b/examples/RabbitPoc/RabbitPoc.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <UserSecretsId>65d4f118-a951-4578-a72e-b061b34373f6</UserSecretsId>
-        <AssemblyName>Innago.Platform.Messaging.ClooudEvents.ConsoleExample</AssemblyName>
+        <AssemblyName>Innago.Platform.Messaging.CloudEvents.ConsoleExample</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/examples/RabbitPoc/RabbitPoc.csproj
+++ b/examples/RabbitPoc/RabbitPoc.csproj
@@ -6,23 +6,29 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <UserSecretsId>65d4f118-a951-4578-a72e-b061b34373f6</UserSecretsId>
+        <AssemblyName>Innago.Platform.Messaging.ClooudEvents.ConsoleExample</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="35.6.3"/>
-        <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.8.0"/>
-        <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0"/>
+        <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" Version="9.0.0" />
+        <PackageReference Include="Bogus" Version="35.6.3" />
+        <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.8.0" />
+        <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
+        <PackageReference Include="Innago.Shared.HealthChecks.TcpHealthProbe" Version="1.0.0" />
         <PackageReference Include="Innago.Shared.TryHelpers" Version="1.1.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4"/>
-        <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0"/>
-        <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0"/>
-        <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0"/>
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0"/>
-        <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.0"/>
-        <PackageReference Include="System.Text.Json" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+        <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+        <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+        <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.0" />
+        <PackageReference Include="System.Text.Json" Version="9.0.5" />
     </ItemGroup>
 
     <ItemGroup>
@@ -36,6 +42,10 @@
       <ProjectReference Include="..\..\src\libraries\EntityEvents\EntityEvents.csproj" />
       <ProjectReference Include="..\..\src\libraries\Publisher.Abstractions\Publisher.Abstractions.csproj" />
       <ProjectReference Include="..\..\src\libraries\Publisher.Amqp\Publisher.Amqp.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
     </ItemGroup>
 
 </Project>

--- a/examples/RabbitPoc/appsettings.json
+++ b/examples/RabbitPoc/appsettings.json
@@ -40,5 +40,12 @@
       "port": "5672",
       "scheme": "AMQP"
     }
-  }
+  },
+  "serviceName": "CloudEvents-RabbitPoc",
+  "serviceVersion": "1.0.0",
+  "healthProbeConfiguration": {
+    "port": 5555,
+    "refreshSeconds": 1
+  },
+  "otlpEndpoint": "http://opentelemetry-collector.observability.svc.cluster.local:14318/v1/traces"
 }

--- a/src/libraries/EntityEvents.Abstractions/EntityEvents.Abstractions.csproj
+++ b/src/libraries/EntityEvents.Abstractions/EntityEvents.Abstractions.csproj
@@ -31,15 +31,15 @@
     <ItemGroup>
         <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.9.0.115408">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.10.0.116381">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/libraries/EntityEvents/EntityEvents.csproj
+++ b/src/libraries/EntityEvents/EntityEvents.csproj
@@ -31,15 +31,15 @@
     <ItemGroup>
         <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.9.0.115408">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.10.0.116381">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/libraries/EntityEvents/PublicAPI.Unshipped.txt
+++ b/src/libraries/EntityEvents/PublicAPI.Unshipped.txt
@@ -11,8 +11,19 @@ Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.TenantId.init -> void
 Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.Verb.get -> Innago.Platform.Messaging.EntityEvents.Verb
 Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.Verb.init -> void
 Innago.Platform.Messaging.EntityEvents.EntityWithIdExtensions
+override Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.ToString() -> string!
 static Innago.Platform.Messaging.EntityEvents.EntityWithIdExtensions.ToCreateEntityEventInfo<TId>(this Innago.Platform.Messaging.EntityEvents.IEntityWithId<TId>! entity, string? tenantId = null) -> Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<Innago.Platform.Messaging.EntityEvents.IEntityWithId<TId>!>!
 static Innago.Platform.Messaging.EntityEvents.EntityWithIdExtensions.ToDeleteEntityEventInfo<TId>(this Innago.Platform.Messaging.EntityEvents.IEntityWithId<TId>! entity, string? tenantId = null) -> Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<Innago.Platform.Messaging.EntityEvents.IEntityWithId<TId>!>!
 static Innago.Platform.Messaging.EntityEvents.EntityWithIdExtensions.ToEntityEventInfo<TId>(this Innago.Platform.Messaging.EntityEvents.IEntityWithId<TId>! entity, Innago.Platform.Messaging.EntityEvents.Verb verb, string? tenantId = null) -> Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<Innago.Platform.Messaging.EntityEvents.IEntityWithId<TId>!>!
 static Innago.Platform.Messaging.EntityEvents.EntityWithIdExtensions.ToPurgeEntityEventInfo<TId>(this Innago.Platform.Messaging.EntityEvents.IEntityWithId<TId>! entity, string? tenantId = null) -> Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<Innago.Platform.Messaging.EntityEvents.IEntityWithId<TId>!>!
 static Innago.Platform.Messaging.EntityEvents.EntityWithIdExtensions.ToUpdateEntityEventInfo<TId>(this Innago.Platform.Messaging.EntityEvents.IEntityWithId<TId>! entity, string? tenantId = null) -> Innago.Platform.Messaging.EntityEvents.IEntityEventInfo<Innago.Platform.Messaging.EntityEvents.IEntityWithId<TId>!>!
+virtual Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.EqualityContract.get -> System.Type!
+virtual Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.PrintMembers(System.Text.StringBuilder! builder) -> bool
+static Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.operator !=(Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>? left, Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>? right) -> bool
+static Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.operator ==(Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>? left, Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>? right) -> bool
+override Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.GetHashCode() -> int
+override Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.Equals(object? obj) -> bool
+virtual Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.Equals(Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>? other) -> bool
+virtual Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.<Clone>$() -> Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>!
+Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.EntityEventInfo(Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>! original) -> void
+Innago.Platform.Messaging.EntityEvents.EntityEventInfo<T>.Deconstruct(out string! Id, out Innago.Platform.Messaging.EntityEvents.Verb Verb, out string? TenantId, out T? Data) -> void

--- a/src/libraries/Publisher.Abstractions/Publisher.Abstractions.csproj
+++ b/src/libraries/Publisher.Abstractions/Publisher.Abstractions.csproj
@@ -31,16 +31,16 @@
     <ItemGroup>
         <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.4" />
-        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.5" />
+        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.9.0.115408">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.10.0.116381">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/libraries/Publisher.Amqp/Publisher.Amqp.csproj
+++ b/src/libraries/Publisher.Amqp/Publisher.Amqp.csproj
@@ -34,23 +34,23 @@
         <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.8.0" />
         <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.4" />
-        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.5" />
+        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.9.0.115408">
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.10.0.116381">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Json" Version="9.0.4" />
+        <PackageReference Include="System.Text.Json" Version="9.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/ApprovalTests/ApprovalTests.csproj
+++ b/tests/ApprovalTests/ApprovalTests.csproj
@@ -25,7 +25,7 @@
         </PackageReference>
         <PackageReference Include="junittestlogger" Version="1.1.0" />
         <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Moq.Analyzers" Version="0.3.0">
             <PrivateAssets>all</PrivateAssets>
@@ -35,7 +35,7 @@
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
-        <PackageReference Include="Verify.Xunit" Version="30.0.0" />
+        <PackageReference Include="Verify.Xunit" Version="30.1.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.OpenCategories" Version="2.1.1.9" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
@@ -57,6 +57,10 @@
 
     <ItemGroup>
       <Folder Include="EntityEvents\ApprovedApi\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Overview
Introduces health check and TCP health probe services to the RabbitPoc example.
Adds OpenTelemetry tracing and metrics configuration, including support for OTLP exporters.
Updates application configuration to include service metadata and observability endpoints.
Adjusts the event publishing interval in the hosted service.

## Summary by Sourcery

Add health checks, TCP health probe, and OpenTelemetry support to the RabbitPoc example while adjusting the event publishing interval

New Features:
- Introduce TCP health probe service and RabbitMQ health checks
- Integrate OpenTelemetry tracing and metrics with OTLP and console exporters

Enhancements:
- Expose service name, version, and observability endpoints in configuration
- Increase event publishing interval from 1s to 30s