### PR TITLE
Close RabbitMQ connection after health check

### DIFF
--- a/examples/RabbitPoc/ProgramConfiguration.cs
+++ b/examples/RabbitPoc/ProgramConfiguration.cs
@@ -54,7 +54,11 @@ internal static class ProgramConfiguration
 
             Result<Connection?> result = await TryHelpers.TryAsync(() => amqpLiteConnectionFactory.CreateAsync(address)).ConfigureAwait(false);
 
-            return result.Map(OnSuccess, OnError);
+            HealthCheckResult healthCheckResult = result.Map(OnSuccess, OnError);
+
+            await result.IfSucceededAsync(connection => connection!.CloseAsync()).ConfigureAwait(false);
+
+            return healthCheckResult;
         }
     }
 
@@ -73,7 +77,7 @@ internal static class ProgramConfiguration
             _ => HealthCheckResult.Healthy(),
         };
 
-        TryHelpers.TryAsync(async () => await (connection?.CloseAsync() ?? Task.CompletedTask).ConfigureAwait(false));
+        // TryHelpers.TryAsync(async () => await (connection?.CloseAsync() ?? Task.CompletedTask).ConfigureAwait(false));
 
         return result;
     }


### PR DESCRIPTION
## Summary by Sourcery

Ensure the RabbitMQ connection is properly closed after running the health check

Enhancements:
- Add an explicit CloseAsync call on successful health check to clean up the connection
- Remove the redundant background close invocation in OnSuccess