### PR TITLE
Changes IConnectionFactory lifetime to transient and creates publisher per message.

### DIFF
--- a/src/libraries/Publisher.Amqp/DependencyInjection.cs
+++ b/src/libraries/Publisher.Amqp/DependencyInjection.cs
@@ -45,7 +45,7 @@ public static class DependencyInjection
 
     private static void Configure(IServiceCollection services, AmqpConfiguration? configuration)
     {
-        services.TryAddSingleton<IConnectionFactory, ConnectionFactory>();
+        services.TryAddTransient<IConnectionFactory, ConnectionFactory>();
 
         services.TryAddTransient<IConnection>(provider =>
         {


### PR DESCRIPTION
## Summary by Sourcery

Change connection factory lifetime to transient and update message publishing to create and dispose a new publisher for each message.

Enhancements:
- Register IConnectionFactory as transient instead of singleton.
- Inject IServiceProvider in MyHostedService and use ActivatorUtilities to create an IPublisher per message.
- Dispose each publisher instance via await using within TryAsync and simplify StopAsync to no-op.