### PR TITLE
Include entire entity event info in message data

### DIFF
--- a/examples/RabbitPoc/MyHostedService.cs
+++ b/examples/RabbitPoc/MyHostedService.cs
@@ -9,8 +9,6 @@ using Innago.Shared.TryHelpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-using Prometheus;
-
 internal class MyHostedService(IServiceProvider provider) : IHostedService
 {
     private static readonly Faker Faker = new();
@@ -24,7 +22,7 @@ internal class MyHostedService(IServiceProvider provider) : IHostedService
             await TryHelpers.TryAsync(async () =>
             {
                 await using var publisher = ActivatorUtilities.GetServiceOrCreateInstance<IPublisher>(provider);
-               await publisher.PublishAsync(entityEvent).ConfigureAwait(false);
+                await publisher.PublishAsync(entityEvent).ConfigureAwait(false);
             }).ConfigureAwait(false);
 
             await Task.Delay(30_000, cancellationToken).ConfigureAwait(false);
@@ -42,13 +40,15 @@ internal class MyHostedService(IServiceProvider provider) : IHostedService
         string entityId = MyHostedService.Faker.Random.AlphaNumeric(8);
         string tenantId = MyHostedService.Faker.Random.AlphaNumeric(8);
 
-        var data = new SomeEntity(MyHostedService.Faker.Commerce.Color());
+        var data = new SomeEntity(
+            MyHostedService.Faker.Commerce.Color(),
+            MyHostedService.Faker.Internet.Email());
 
         var info = new EntityEventInfo<SomeEntity>(entityId, verb, tenantId, Data: data);
-        
+
         return info;
     }
 
-    // ReSharper disable once NotAccessedPositionalProperty.Local
-    private record SomeEntity(string Value);
+    // ReSharper disable NotAccessedPositionalProperty.Local
+    private record SomeEntity(string Value, string EmailAddress);
 }

--- a/src/libraries/EntityEvents.Abstractions/EntityEventInfoExtensions.cs
+++ b/src/libraries/EntityEvents.Abstractions/EntityEventInfoExtensions.cs
@@ -27,7 +27,7 @@ public static class EntityEventInfoExtensions
             Id = Guid.NewGuid().ToString(),
             Source = new Uri(EntityEventInfoExtensions.Source),
             Type = EntityEventInfoExtensions.EventType,
-            Data = entityEventInfo.Data,
+            Data = entityEventInfo,
             Subject = entityEventInfo.Subject,
             Time = DateTimeOffset.UtcNow,
         };

--- a/src/libraries/Publisher.Amqp/Publisher.cs
+++ b/src/libraries/Publisher.Amqp/Publisher.cs
@@ -36,7 +36,7 @@ public sealed class Publisher(
     /// <inheritdoc />
     public async Task PublishAsync<T>(CloudEvent cloudEvent)
     {
-        CloudEventFormatter formatter = new JsonEventFormatter<T>();
+        CloudEventFormatter formatter = new JsonEventFormatter<IEntityEventInfo<T>>();
 
         Message message = cloudEvent.ToAmqpMessage(ContentMode.Binary, formatter);
 

--- a/src/libraries/Publisher.Amqp/SourceGeneratorContext.cs
+++ b/src/libraries/Publisher.Amqp/SourceGeneratorContext.cs
@@ -2,6 +2,8 @@ namespace Innago.Platform.Messaging.Publisher.Amqp;
 
 using System.Text.Json.Serialization;
 
+using EntityEvents;
+
 [JsonSerializable(typeof(Dictionary<string, object>))]
 [JsonSerializable(typeof(Uri))]
 [JsonSerializable(typeof(DateTimeOffset))]


### PR DESCRIPTION
## Summary by Sourcery

Extend message serialization to include complete entity event information and update example entity to include additional field

New Features:
- Add EmailAddress property to SomeEntity in example for richer event data

Enhancements:
- Serialize the full IEntityEventInfo<T> as CloudEvent Data instead of only the Data payload
- Configure AMQP publisher to use JsonEventFormatter<IEntityEventInfo<T>> and adjust CloudEvent extension accordingly
- Register EntityEvents namespace in JSON source generator context for proper serialization support