### PR TITLE
Removes string enum converter and adds source generator tests.

### DIFF
--- a/src/libraries/Publisher.Amqp/SourceGeneratorContext.cs
+++ b/src/libraries/Publisher.Amqp/SourceGeneratorContext.cs
@@ -2,7 +2,7 @@ namespace Innago.Platform.Messaging.Publisher.Amqp;
 
 using System.Text.Json.Serialization;
 
-[JsonSourceGenerationOptions(UseStringEnumConverter = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(Dictionary<string, object>))]
 [JsonSerializable(typeof(Uri))]
 [JsonSerializable(typeof(DateTimeOffset))]

--- a/tests/UnitTests/Publisher.Amqp/SourceGeneratorContextTests.cs
+++ b/tests/UnitTests/Publisher.Amqp/SourceGeneratorContextTests.cs
@@ -1,0 +1,38 @@
+namespace UnitTests.Publisher.Amqp;
+
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Innago.Platform.Messaging.EntityEvents;
+using Innago.Platform.Messaging.Publisher.Amqp;
+
+using Xunit.OpenCategories;
+
+[UnitTest(nameof(SourceGeneratorContext))]
+public class SourceGeneratorContextTests
+{
+    [Fact]
+    public void DateTimeOffsetShouldBeSetup()
+    {
+        SourceGeneratorContext.Default.GetTypeInfo(typeof(DateTimeOffset)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void DictionaryStringObjectShouldBeSetup()
+    {
+        SourceGeneratorContext.Default.GetTypeInfo(typeof(Dictionary<string, object>)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void UriShouldBeSetup()
+    {
+        SourceGeneratorContext.Default.GetTypeInfo(typeof(Uri)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void EnumsShouldSerializeAsStrings()
+    {
+        SourceGeneratorContext.Default.Options.PropertyNamingPolicy.Should().Be(JsonNamingPolicy.CamelCase);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Remove string enum converter option from JSON source generation and add unit tests to verify supported types and camelCase naming policy in SourceGeneratorContext.

Enhancements:
- Remove UseStringEnumConverter configuration from JsonSourceGenerationOptions in SourceGeneratorContext.

Tests:
- Add unit tests verifying DateTimeOffset, Dictionary<string, object>, and Uri type info setup in SourceGeneratorContext.
- Add unit test validating camelCase PropertyNamingPolicy in SourceGeneratorContext.Options.